### PR TITLE
Rename field constants

### DIFF
--- a/src/SweetEnum.php
+++ b/src/SweetEnum.php
@@ -139,7 +139,7 @@ trait SweetEnum
      *                                - self::FIELDS_SWEET_FULL
      *                                - custom array with values
      */
-    public function toArray(array|string $fields = self::FIELDS_SWEET_BASIC): array
+    public function toArray(array|string $fields = self::FIELDS_BASIC): array
     {
         if (is_array($fields)) {
             if (count($fields) < 1) {
@@ -169,18 +169,18 @@ trait SweetEnum
                     'value' => $this->value,
                     'name' => $this->name,
                 ];
-            case self::FIELDS_SWEET_BASIC:
+            case self::FIELDS_BASIC:
                 return [
                     'id' => $this->id(),
                     'title' => $this->title(),
                 ];
-            case self::FIELDS_SWEET_WITH_STATUS:
+            case self::FIELDS_BASIC_WITH_STATUS:
                 return [
                     'isOn' => $this->isOn(),
                     'id' => $this->id(),
                     'title' => $this->title(),
                 ];
-            case self::FIELDS_SWEET_FULL:
+            case self::FIELDS_FULL:
                 $output = [
                     'isOn' => $this->isOn(),
                     'value' => $this->value,
@@ -228,7 +228,7 @@ trait SweetEnum
      *
      * @return array<string, array>
      */
-    public static function getCasesInfo(array|string $fields = self::FIELDS_SWEET_BASIC, bool $onlyActive = true): array
+    public static function getCasesInfo(array|string $fields = self::FIELDS_BASIC, bool $onlyActive = true): array
     {
         return static::map(fn (SweetEnumContract $case) => $case->toArray($fields), $onlyActive);
     }

--- a/src/SweetEnumContract.php
+++ b/src/SweetEnumContract.php
@@ -16,9 +16,18 @@ interface SweetEnumContract
 
     public const FIELDS_ORIGINAL = 'original'; // enum original values (value / name)
 
-    public const FIELDS_SWEET_BASIC = 'sweet-basic'; // only id / title
+    public const FIELDS_BASIC = 'basic'; // only id / title
 
-    public const FIELDS_SWEET_WITH_STATUS = 'sweet-with-status'; // only id / title / isOn
+    public const FIELDS_BASIC_WITH_STATUS = 'basic-with-status'; // only id / title / isOn
 
-    public const FIELDS_SWEET_FULL = 'sweet-full'; // All fields including custom and computed
+    public const FIELDS_FULL = 'full'; // All fields including custom and computed
+
+    /** @deprecated - please use `FIELDS_BASIC` */
+    public const FIELDS_SWEET_BASIC = self::FIELDS_BASIC;
+
+    /** @deprecated - please use `FIELDS_BASIC_WITH_STATUS` */
+    public const FIELDS_SWEET_WITH_STATUS = self::FIELDS_BASIC_WITH_STATUS;
+
+    /** @deprecated - please use `FIELDS_FULL` */
+    public const FIELDS_SWEET_FULL = self::FIELDS_FULL;
 }

--- a/tests/Feature/BulkCasesTest.php
+++ b/tests/Feature/BulkCasesTest.php
@@ -118,9 +118,9 @@ describe('Bulk cases', function () {
 
     test('if not added to computed values then values from public methods are not available on info array unless manually prompted', function () {
         expect(Color::getCasesInfo(Color::FIELDS_ORIGINAL)['blue'])->not()->toHaveKeys(['cmyk'])
-            ->and(Color::getCasesInfo(Color::FIELDS_SWEET_BASIC)['blue'])->not()->toHaveKeys(['cmyk'])
-            ->and(Color::getCasesInfo(Color::FIELDS_SWEET_WITH_STATUS)['blue'])->not()->toHaveKeys(['cmyk'])
-            ->and(Color::getCasesInfo(Color::FIELDS_SWEET_FULL)['blue'])->not()->toHaveKeys(['cmyk'])
+            ->and(Color::getCasesInfo(Color::FIELDS_BASIC)['blue'])->not()->toHaveKeys(['cmyk'])
+            ->and(Color::getCasesInfo(Color::FIELDS_BASIC_WITH_STATUS)['blue'])->not()->toHaveKeys(['cmyk'])
+            ->and(Color::getCasesInfo(Color::FIELDS_FULL)['blue'])->not()->toHaveKeys(['cmyk'])
             ->and(Color::getCasesInfo(['cmyk'])['blue'])->toHaveKeys(['cmyk']);
     });
 });

--- a/tests/Feature/CaseClassesTest.php
+++ b/tests/Feature/CaseClassesTest.php
@@ -33,7 +33,7 @@ describe('Access options', function () {
     });
 
     it('can access case class public values when returning case as array', function () {
-        expect(Animal::Sheep->toArray(Animal::FIELDS_SWEET_FULL))->toMatchArray([
+        expect(Animal::Sheep->toArray(Animal::FIELDS_FULL))->toMatchArray([
             'title' => 'Sheep',
             'bark' => 'Sorry, a sheep cannot bark',
             'meow' => 'Sorry, a sheep cannot meow',

--- a/tests/Feature/SingleCaseTest.php
+++ b/tests/Feature/SingleCaseTest.php
@@ -57,7 +57,7 @@ describe('Single case', function () {
     });
 
     it('can return all its basic values with the status as an array', function () {
-        expect(Color::Blue->toArray(Color::FIELDS_SWEET_WITH_STATUS))->toBe([
+        expect(Color::Blue->toArray(Color::FIELDS_BASIC_WITH_STATUS))->toBe([
             'isOn' => true,
             'id' => 'blue',
             'title' => 'Blue color',
@@ -65,7 +65,7 @@ describe('Single case', function () {
     });
 
     it('can return all its values (including custom) with the status as an array', function () {
-        expect(Color::Blue->toArray(Color::FIELDS_SWEET_FULL))->toBe([
+        expect(Color::Blue->toArray(Color::FIELDS_FULL))->toBe([
             'isOn' => true,
             'value' => 'blue',
             'id' => 'blue',
@@ -95,9 +95,9 @@ describe('Single case', function () {
 
     test('if not added to computed values then values from public methods are not available on info array unless manually prompted', function () {
         expect(Color::Blue->toArray(Color::FIELDS_ORIGINAL))->not()->toHaveKeys(['cmyk'])
-            ->and(Color::Blue->toArray(Color::FIELDS_SWEET_BASIC))->not()->toHaveKeys(['cmyk'])
-            ->and(Color::Blue->toArray(Color::FIELDS_SWEET_WITH_STATUS))->not()->toHaveKeys(['cmyk'])
-            ->and(Color::Blue->toArray(Color::FIELDS_SWEET_FULL))->not()->toHaveKeys(['cmyk'])
+            ->and(Color::Blue->toArray(Color::FIELDS_BASIC))->not()->toHaveKeys(['cmyk'])
+            ->and(Color::Blue->toArray(Color::FIELDS_BASIC_WITH_STATUS))->not()->toHaveKeys(['cmyk'])
+            ->and(Color::Blue->toArray(Color::FIELDS_FULL))->not()->toHaveKeys(['cmyk'])
             ->and(Color::Blue->toArray(['cmyk']))->toHaveKeys(['cmyk']);
     });
 


### PR DESCRIPTION
Rename field constants (and mark old ones as deprecated) to reduce wording